### PR TITLE
Refactored namespace to match library

### DIFF
--- a/src/Lite.EventIpc.Tests/BaseTestClass.cs
+++ b/src/Lite.EventIpc.Tests/BaseTestClass.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Lite.EventAggregator.Tests;
+namespace Lite.EventIpc.Tests;
 
 [TestClass]
 public class BaseTestClass

--- a/src/Lite.EventIpc.Tests/IpcOneWayTransporter/MemoryMappedTests.cs
+++ b/src/Lite.EventIpc.Tests/IpcOneWayTransporter/MemoryMappedTests.cs
@@ -5,10 +5,10 @@ using System;
 using System.Net;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
-using Lite.EventAggregator.Tests.Models;
-using Lite.EventAggregator.IpcTransport;
+using Lite.EventIpc.Tests.Models;
+using Lite.EventIpc.IpcTransport;
 
-namespace Lite.EventAggregator.Tests.IpcOneWayTransporter;
+namespace Lite.EventIpc.Tests.IpcOneWayTransporter;
 
 [SupportedOSPlatform("windows")]
 [TestClass]

--- a/src/Lite.EventIpc.Tests/IpcOneWayTransporter/NamedPipesTests.cs
+++ b/src/Lite.EventIpc.Tests/IpcOneWayTransporter/NamedPipesTests.cs
@@ -2,10 +2,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
-using Lite.EventAggregator.IpcTransport;
-using Lite.EventAggregator.Tests.Models;
+using Lite.EventIpc.IpcTransport;
+using Lite.EventIpc.Tests.Models;
 
-namespace Lite.EventAggregator.Tests.IpcOneWayTransporter;
+namespace Lite.EventIpc.Tests.IpcOneWayTransporter;
 
 [TestClass]
 [DoNotParallelize]

--- a/src/Lite.EventIpc.Tests/IpcOneWayTransporter/TcpTransportTests.cs
+++ b/src/Lite.EventIpc.Tests/IpcOneWayTransporter/TcpTransportTests.cs
@@ -3,10 +3,10 @@
 
 using System.Net;
 using System.Threading.Tasks;
-using Lite.EventAggregator.Tests.Models;
-using Lite.EventAggregator.IpcTransport;
+using Lite.EventIpc.Tests.Models;
+using Lite.EventIpc.IpcTransport;
 
-namespace Lite.EventAggregator.Tests.IpcOneWayTransporter;
+namespace Lite.EventIpc.Tests.IpcOneWayTransporter;
 
 [TestClass]
 [DoNotParallelize]

--- a/src/Lite.EventIpc.Tests/IpcReceiptedTransporters/MemoryMappedTests.cs
+++ b/src/Lite.EventIpc.Tests/IpcReceiptedTransporters/MemoryMappedTests.cs
@@ -5,10 +5,10 @@
 using System;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
-using Lite.EventAggregator.IpcReceiptTransport;
-using Lite.EventAggregator.Tests.Models;
+using Lite.EventIpc.IpcReceiptTransport;
+using Lite.EventIpc.Tests.Models;
 
-namespace Lite.EventAggregator.Tests.IpcReceiptedTransporters;
+namespace Lite.EventIpc.Tests.IpcReceiptedTransporters;
 
 [SupportedOSPlatform("windows")]
 [TestClass]

--- a/src/Lite.EventIpc.Tests/IpcReceiptedTransporters/NamedPipesTests.cs
+++ b/src/Lite.EventIpc.Tests/IpcReceiptedTransporters/NamedPipesTests.cs
@@ -4,10 +4,10 @@
 
 using System;
 using System.Threading.Tasks;
-using Lite.EventAggregator.IpcReceiptTransport;
-using Lite.EventAggregator.Tests.Models;
+using Lite.EventIpc.IpcReceiptTransport;
+using Lite.EventIpc.Tests.Models;
 
-namespace Lite.EventAggregator.Tests.IpcReceiptedTransporters;
+namespace Lite.EventIpc.Tests.IpcReceiptedTransporters;
 
 [TestClass]
 [DoNotParallelize]

--- a/src/Lite.EventIpc.Tests/IpcReceiptedTransporters/TcpTransportTests.cs
+++ b/src/Lite.EventIpc.Tests/IpcReceiptedTransporters/TcpTransportTests.cs
@@ -5,10 +5,10 @@
 using System;
 using System.Net;
 using System.Threading.Tasks;
-using Lite.EventAggregator.IpcReceiptTransport;
-using Lite.EventAggregator.Tests.Models;
+using Lite.EventIpc.IpcReceiptTransport;
+using Lite.EventIpc.Tests.Models;
 
-namespace Lite.EventAggregator.Tests.IpcReceiptedTransporters;
+namespace Lite.EventIpc.Tests.IpcReceiptedTransporters;
 
 [TestClass]
 [DoNotParallelize]

--- a/src/Lite.EventIpc.Tests/LocalEvents/AggregatorTests.cs
+++ b/src/Lite.EventIpc.Tests/LocalEvents/AggregatorTests.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Threading.Tasks;
-using Lite.EventAggregator.Tests.Models;
+using Lite.EventIpc.Tests.Models;
 
-namespace Lite.EventAggregator.Tests.LocalEvents;
+namespace Lite.EventIpc.Tests.LocalEvents;
 
 [TestClass]
 public class AggregatorTests : BaseTestClass

--- a/src/Lite.EventIpc.Tests/LocalEvents/WeakReferenceTests.cs
+++ b/src/Lite.EventIpc.Tests/LocalEvents/WeakReferenceTests.cs
@@ -2,9 +2,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Lite.EventAggregator.Tests.Models;
+using Lite.EventIpc.Tests.Models;
 
-namespace Lite.EventAggregator.Tests.LocalEvents;
+namespace Lite.EventIpc.Tests.LocalEvents;
 
 [TestClass]
 public class WeakReferenceTests : BaseTestClass

--- a/src/Lite.EventIpc.Tests/Models/PingPong.cs
+++ b/src/Lite.EventIpc.Tests/Models/PingPong.cs
@@ -1,7 +1,7 @@
 // Copyright Xeno Innovations, Inc. 2025
 // See the LICENSE file in the project root for more information.
 
-namespace Lite.EventAggregator.Tests.Models;
+namespace Lite.EventIpc.Tests.Models;
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "Tiny Ping/Pong")]
 public record Ping(string Message);

--- a/src/Lite.EventIpc.Tests/Models/UserCreatedEvent.cs
+++ b/src/Lite.EventIpc.Tests/Models/UserCreatedEvent.cs
@@ -1,7 +1,7 @@
 // Copyright Xeno Innovations, Inc. 2025
 // See the LICENSE file in the project root for more information.
 
-namespace Lite.EventAggregator.Tests.Models;
+namespace Lite.EventIpc.Tests.Models;
 
 public class UserCreatedEvent
 {

--- a/src/Lite.EventIpc/Core/IRequestHandler.cs
+++ b/src/Lite.EventIpc/Core/IRequestHandler.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace Lite.EventAggregator.Core;
+namespace Lite.EventIpc.Core;
 
 internal interface IRequestHandler
 {

--- a/src/Lite.EventIpc/Core/IWeakAction.cs
+++ b/src/Lite.EventIpc/Core/IWeakAction.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Lite.EventAggregator.Core;
+namespace Lite.EventIpc.Core;
 
 /// <summary>
 ///   Defines a contract for actions that reference event handlers using weak references, enabling invocation and lifetime

--- a/src/Lite.EventIpc/Core/RequestHandler.cs
+++ b/src/Lite.EventIpc/Core/RequestHandler.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace Lite.EventAggregator.Core;
+namespace Lite.EventIpc.Core;
 
 /// <summary>
 ///   Provides a handler for asynchronous requests and responses, associating a delegate with specific request and

--- a/src/Lite.EventIpc/Core/WeakAction.cs
+++ b/src/Lite.EventIpc/Core/WeakAction.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Lite.EventAggregator.Core;
+namespace Lite.EventIpc.Core;
 
 /// <summary>Stores a weak reference to the delegate, and a typed invoker.</summary>
 internal sealed class WeakAction<T> : IWeakAction

--- a/src/Lite.EventIpc/DI/EventAggregatorTransportHostedService.cs
+++ b/src/Lite.EventIpc/DI/EventAggregatorTransportHostedService.cs
@@ -4,11 +4,11 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Lite.EventAggregator.IpcReceiptTransport;
-using Lite.EventAggregator.IpcTransport;
+using Lite.EventIpc.IpcReceiptTransport;
+using Lite.EventIpc.IpcTransport;
 using Microsoft.Extensions.Hosting;
 
-namespace Lite.EventAggregator;
+namespace Lite.EventIpc;
 
 public sealed class EventAggregatorTransportHostedService : IHostedService
 {

--- a/src/Lite.EventIpc/EventAggregator.cs
+++ b/src/Lite.EventIpc/EventAggregator.cs
@@ -7,11 +7,11 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Lite.EventAggregator.Core;
-using Lite.EventAggregator.IpcReceiptTransport;
-using Lite.EventAggregator.IpcTransport;
+using Lite.EventIpc.Core;
+using Lite.EventIpc.IpcReceiptTransport;
+using Lite.EventIpc.IpcTransport;
 
-namespace Lite.EventAggregator;
+namespace Lite.EventIpc;
 
 /// <summary>
 ///   Provides a central hub for publishing events and handling request/response messaging between loosely coupled

--- a/src/Lite.EventIpc/EventEnvelope.cs
+++ b/src/Lite.EventIpc/EventEnvelope.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Lite.EventAggregator;
+namespace Lite.EventIpc;
 
 /// <summary>Event Envelope.</summary>
 public sealed class EventEnvelope

--- a/src/Lite.EventIpc/EventSerializer.cs
+++ b/src/Lite.EventIpc/EventSerializer.cs
@@ -1,7 +1,7 @@
 // Copyright Xeno Innovations, Inc. 2025
 // See the LICENSE file in the project root for more information.
 
-namespace Lite.EventAggregator;
+namespace Lite.EventIpc;
 
 using System;
 using System.Text.Json;

--- a/src/Lite.EventIpc/Extensions/EventAggregatorServiceCollectionExtensions.cs
+++ b/src/Lite.EventIpc/Extensions/EventAggregatorServiceCollectionExtensions.cs
@@ -1,10 +1,10 @@
 // Copyright Xeno Innovations, Inc. 2025
 // See the LICENSE file in the project root for more information.
 #if PREVIEW
-using Lite.EventAggregator.IpcTransport;
+using Lite.EventIpc.IpcTransport;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Lite.EventAggregator.Extensions;
+namespace Lite.EventIpc.Extensions;
 
 public static class EventAggregatorServiceCollectionExtensions
 {

--- a/src/Lite.EventIpc/IEventAggregator.cs
+++ b/src/Lite.EventIpc/IEventAggregator.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Lite.EventAggregator.IpcReceiptTransport;
-using Lite.EventAggregator.IpcTransport;
+using Lite.EventIpc.IpcReceiptTransport;
+using Lite.EventIpc.IpcTransport;
 
-namespace Lite.EventAggregator;
+namespace Lite.EventIpc;
 
 public interface IEventAggregator
 {

--- a/src/Lite.EventIpc/IpcReceiptTransport/IEventEnvelopeTransport.cs
+++ b/src/Lite.EventIpc/IpcReceiptTransport/IEventEnvelopeTransport.cs
@@ -5,7 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Lite.EventAggregator.IpcReceiptTransport;
+namespace Lite.EventIpc.IpcReceiptTransport;
 
 /// <summary>
 ///   Bi-directional event transport interface used for sending and receiving event packages, AKA: "envelopes".

--- a/src/Lite.EventIpc/IpcReceiptTransport/MemoryMappedEnvelopeTransport.cs
+++ b/src/Lite.EventIpc/IpcReceiptTransport/MemoryMappedEnvelopeTransport.cs
@@ -11,7 +11,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Lite.EventAggregator.IpcReceiptTransport;
+namespace Lite.EventIpc.IpcReceiptTransport;
 
 /// <summary>Memory-Mapped IPC Transport - Async + Bi-Directional (Windows OS only).</summary>
 /// <remarks>

--- a/src/Lite.EventIpc/IpcReceiptTransport/NamedPipeEnvelopeTransport.cs
+++ b/src/Lite.EventIpc/IpcReceiptTransport/NamedPipeEnvelopeTransport.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Lite.EventAggregator.IpcReceiptTransport;
+namespace Lite.EventIpc.IpcReceiptTransport;
 
 /// <summary>
 ///   Provides an async + bi-directional event envelope transport mechanism

--- a/src/Lite.EventIpc/IpcReceiptTransport/TcpEnvelopeTransport.cs
+++ b/src/Lite.EventIpc/IpcReceiptTransport/TcpEnvelopeTransport.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Lite.EventAggregator.IpcReceiptTransport;
+namespace Lite.EventIpc.IpcReceiptTransport;
 
 /// <summary>
 ///   Provides TCP-based transport for sending and receiving async bi-directional event envelopes,

--- a/src/Lite.EventIpc/IpcTransport/IEventTransport.cs
+++ b/src/Lite.EventIpc/IpcTransport/IEventTransport.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Lite.EventAggregator.IpcTransport;
+namespace Lite.EventIpc.IpcTransport;
 
 /// <summary>
 ///   Bi-directional event transport interface used for sending and receiving event packages, AKA: "envelopes".

--- a/src/Lite.EventIpc/IpcTransport/MemoryMappedTransport.cs
+++ b/src/Lite.EventIpc/IpcTransport/MemoryMappedTransport.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Lite.EventAggregator.IpcTransport;
+namespace Lite.EventIpc.IpcTransport;
 
 /// <summary>Memory-Mapped IPC Transport (Windows OS only).</summary>
 [SupportedOSPlatform("windows")]

--- a/src/Lite.EventIpc/IpcTransport/NamedPipeTransport.cs
+++ b/src/Lite.EventIpc/IpcTransport/NamedPipeTransport.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Lite.EventAggregator.IpcTransport;
+namespace Lite.EventIpc.IpcTransport;
 
 public class NamedPipeTransport : IEventTransport
 {

--- a/src/Lite.EventIpc/IpcTransport/TcpTransport.cs
+++ b/src/Lite.EventIpc/IpcTransport/TcpTransport.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Lite.EventAggregator.IpcTransport;
+namespace Lite.EventIpc.IpcTransport;
 
 /// <summary>TCP/IP IPC Transport.</summary>
 public class TcpTransport : IEventTransport

--- a/src/SampleApp/IpcTransporters/AspNetDISample.cs
+++ b/src/SampleApp/IpcTransporters/AspNetDISample.cs
@@ -11,7 +11,7 @@ public class AspNetDISample
 {
   /*
   using System.Net;
-  using Lite.EventAggregator;
+  using Lite.EventIpc;
   using Microsoft.AspNetCore.Builder;
   using Microsoft.Extensions.DependencyInjection;
 

--- a/src/SampleApp/IpcTransporters/IpcOneWay.cs
+++ b/src/SampleApp/IpcTransporters/IpcOneWay.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Lite.EventAggregator;
-using Lite.EventAggregator.IpcTransport;
+using Lite.EventIpc;
+using Lite.EventIpc.IpcTransport;
 
 namespace SampleApp.IpcTransporters;
 

--- a/src/SampleApp/IpcTransporters/MemoryMapDemo.cs
+++ b/src/SampleApp/IpcTransporters/MemoryMapDemo.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
-using Lite.EventAggregator;
-using Lite.EventAggregator.IpcReceiptTransport;
+using Lite.EventIpc;
+using Lite.EventIpc.IpcReceiptTransport;
 
 namespace SampleApp.IpcTransporters;
 

--- a/src/SampleApp/IpcTransporters/NamedPipesDemo.cs
+++ b/src/SampleApp/IpcTransporters/NamedPipesDemo.cs
@@ -4,8 +4,8 @@
 
 using System;
 using System.Threading.Tasks;
-using Lite.EventAggregator;
-using Lite.EventAggregator.IpcReceiptTransport;
+using Lite.EventIpc;
+using Lite.EventIpc.IpcReceiptTransport;
 
 namespace SampleApp.IpcTransporters;
 

--- a/src/SampleApp/IpcTransporters/TcpDemo.cs
+++ b/src/SampleApp/IpcTransporters/TcpDemo.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Net;
 using System.Threading.Tasks;
-using Lite.EventAggregator;
-using Lite.EventAggregator.IpcReceiptTransport;
+using Lite.EventIpc;
+using Lite.EventIpc.IpcReceiptTransport;
 
 namespace SampleApp.IpcTransporters;
 

--- a/src/SampleApp/Program.cs
+++ b/src/SampleApp/Program.cs
@@ -2,7 +2,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Lite.EventAggregator;
+using Lite.EventIpc;
 
 namespace SampleApp;
 


### PR DESCRIPTION
Refactored namespace to match library name "Lite.EventAggregator" -> "Lite.EventIpc"